### PR TITLE
Fix Rational negate bug

### DIFF
--- a/Sources/Math/Rational.swift
+++ b/Sources/Math/Rational.swift
@@ -87,7 +87,7 @@ extension Rational {
 
     /// Negate `Rational` type arithmetically.
     public static prefix func - (rational: Self) -> Self {
-        return -rational
+        return .init(-rational.numerator, rational.denominator)
     }
 }
 


### PR DESCRIPTION
This PR prevents the negation of a `Rational` type from calling itself recursively until the stack blows up.