### PR TITLE
Add @inlinable to various operations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
           "branch": null,
-          "revision": "2ac564721eb0aee2e886cec6d69e107ebb556113",
-          "version": "0.8.0"
+          "revision": "80fb30574cb33852c46243807255593c56ca7ab1",
+          "version": "0.14.0"
         }
       }
     ]

--- a/Sources/Math/DoubleExtensions.swift
+++ b/Sources/Math/DoubleExtensions.swift
@@ -17,10 +17,8 @@ extension Double {
     /// Exponentially scales a `Double` from the given `source` to the given
     /// `destination`.
     ///
-    #warning("""
-    Abstract Double.scale(from:to:) over `FloatingPoint`. This requires writing a `pow(_:)` which
-    is generic over `FloatingPoint` values.
-    """)
+    // FIXME: Abstract Double.scale(from:to:) over `FloatingPoint`. This requires writing a `pow(_:)`
+    // which is generic over `FloatingPoint` values.
     public mutating func scale(
         from source: ClosedRange<Double>,
         toExponential destination: ClosedRange<Double>
@@ -35,10 +33,8 @@ extension Double {
     /// - returns: A `Double` value scaled from the given `source` range to the
     /// given `destination` range.
     ///
-    #warning("""
-    Abstract Double.scaled(from:to:) over `FloatingPoint`. This requires writing a `pow(_:)` which
-    is generic over `FloatingPoint` values.
-    """)
+    // FIXME: Abstract Double.scale(from:toExponential:) over `FloatingPoint`. This requires writing
+    // a `pow(_:)`  which is generic over `FloatingPoint` values.
     public func scaled(
         from source: ClosedRange<Double>,
         toExponential destination: ClosedRange<Double>

--- a/Sources/Math/Functions.swift
+++ b/Sources/Math/Functions.swift
@@ -7,17 +7,20 @@
 //
 
 /// - Returns: The average to the two given values.
+@inlinable
 public func mean <F: FloatingPoint> (_ a: F, _ b: F) -> F {
     return (a + b) / 2
 }
 
 /// - Returns: Divisor modulo (as opposed to the remainder implemented by Swift's `%` operator).
+@inlinable
 public func mod <T: BinaryInteger> (_ dividend: T, _ modulus: T) -> T {
     let result = dividend % modulus
     return result < 0 ? result + modulus : result
 }
 
 /// - Returns: Divisor modulo (as opposed to the remainder implemented by Swift's `%` operator).
+@inlinable
 public func mod <T: FloatingPoint> (_ dividend: T, _ modulus: T) -> T {
     let result = dividend.truncatingRemainder(dividingBy: modulus)
     return result < 0 ? result + modulus : result

--- a/Sources/Math/GCDDomain.swift
+++ b/Sources/Math/GCDDomain.swift
@@ -7,12 +7,14 @@
 //
 
 /// - Returns: Greatest common divisor of `a` and `b`.
+@inlinable
 public func gcd <I: BinaryInteger> (_ a: I, _ b: I) -> I {
     let result = a % b
     return result == 0 ? b : gcd(b, result)
 }
 
 /// - Returns: Least common multiple of `a` and `b`.
+@inlinable
 public func lcm <I: BinaryInteger> (_ a: I, _ b: I) -> I {
     return (a / gcd(a,b)) * b
 }
@@ -23,6 +25,7 @@ extension Sequence where Element: BinaryInteger {
     ///
     ///     let gcd = [8,12].gcd // => 4
     ///
+    @inlinable
     public var gcd: Element {
         return reduce(0, Math.gcd)
     }
@@ -31,6 +34,7 @@ extension Sequence where Element: BinaryInteger {
     ///
     ///     let lcm = [4,5,6].lcm // => 60
     ///
+    @inlinable
     public var lcm: Element {
         return reduce(1, Math.lcm)
     }

--- a/Sources/Math/Quadratic.swift
+++ b/Sources/Math/Quadratic.swift
@@ -31,6 +31,7 @@
 ///
 /// In this case, there are two results.
 ///
+@inlinable
 public func quadratic <T: FloatingPoint> (_ a: T, _ b: T, _ c: T) -> Set<T> {
     if a == 0 { return [] }
     let discriminant = b * b - 4 * a * c

--- a/Sources/Math/Rational.swift
+++ b/Sources/Math/Rational.swift
@@ -109,6 +109,7 @@ extension Rational {
 extension Rational {
 
     /// - Returns: Representation of a `Rational` value with a given `numerator`.
+    @inlinable
     public func scaling(numerator newNumerator: Int) -> Self {
         guard newNumerator != numerator else { return self }
         let quotient = Double(newNumerator) / Double(numerator)
@@ -118,6 +119,7 @@ extension Rational {
     }
 
     /// - Returns: Representation of a `Rational` value with a given `denominator`.
+    @inlinable
     public func scaling(denominator newDenominator: Int) -> Self {
         guard newDenominator != denominator else { return self }
         guard numerator != 0 else { return Self(0, newDenominator) }
@@ -239,6 +241,7 @@ extension Rational {
 extension Rational {
 
     /// Reduced version of `self`.
+    @inlinable
     public var reduced: Self {
         let common = gcd(abs(numerator), abs(denominator))
         let sign = denominator > 0 ? 1 : -1
@@ -252,6 +255,7 @@ extension Rational {
 
     /// - returns: `true` if the left `Rational` is less than the right `Rational`. Otherwise,
     /// `false`.
+    @inlinable
     public static func < (lhs: Self, rhs: Self) -> Bool {
         let (lhs, rhs) = normalized(lhs, rhs)
         return lhs.numerator < rhs.numerator
@@ -263,17 +267,20 @@ extension Rational {
     // MARK: - Equatable
 
     /// - returns: Pair of `Rational` values, each in their most-reduced form.
+    @inlinable
     public static func reduced <R: Rational> (_ a: R, _ b: R) -> (R, R) {
         return (a.reduced, b.reduced)
     }
 
     /// - returns: Pair of `Rational` values, with common denominators.
+    @inlinable
     public static func normalized <R: Rational> (_ a: R, _ b: R) -> (R, R) {
         let commonDenominator = lcm(a.denominator, b.denominator)
         return map(a,b) { $0.scaling(denominator: commonDenominator) }
     }
 
     /// - returns: `true` if both values are equivalent in their most-reduced form.
+    @inlinable
     public static func == (lhs: Self, rhs: Self) -> Bool {
         let (lhs, rhs) = normalized(lhs, rhs)
         return lhs.numerator == rhs.numerator

--- a/Tests/MathTests/GreatestCommonDivisorTests.swift
+++ b/Tests/MathTests/GreatestCommonDivisorTests.swift
@@ -24,4 +24,12 @@ class GreatestCommonDivisorTests: XCTestCase {
         let greatestCommonDivisor = gcd(a,b)
         XCTAssertEqual(greatestCommonDivisor, 4)
     }
+
+    func testMany() {
+        let numbers = (1..<1_000_000)
+        let values = zip(numbers, numbers.reversed())
+        measure {
+            values.forEach { a,b in _ = gcd(a,b) }
+        }
+    }
 }

--- a/Tests/MathTests/QuadraticTests.swift
+++ b/Tests/MathTests/QuadraticTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import DataStructures
 import Math
 
 class QuadraticTests: XCTestCase {
@@ -29,5 +30,14 @@ class QuadraticTests: XCTestCase {
     func testQuadraticDouble() {
         let result: Set<Double> = quadratic(5,6,1)
         XCTAssertEqual(result, [-1, -0.2])
+    }
+
+    func testMany() {
+        let a = stride(from: 0.0, to: 1_000_000, by: 1)
+        let b = a.reversed()
+        let c = zip(a,b).map(*)
+        measure {
+            zip(a,b,c).forEach { a,b,c in let _ = quadratic(a,b,c) }
+        }
     }
 }

--- a/Tests/MathTests/RationalTests.swift
+++ b/Tests/MathTests/RationalTests.swift
@@ -255,4 +255,20 @@ class RationalTests: XCTestCase {
         XCTAssertEqual(a, Fraction(44,21))
     }
 
+    func testManyFractionsReudced() {
+        let numbers = (1..<1_000_000)
+        let fractions = zip(numbers,numbers.reversed()).map { n,d in Fraction(n,d) }
+        measure {
+            _ = fractions.map { $0.reduced }
+        }
+    }
+
+    func testManyFractionsNormalized() {
+        let numbers = (1..<1_000_000)
+        let xs = zip(numbers,numbers.reversed()).map { n,d in Fraction(n,d) }
+        let ys = zip(numbers.reversed(),numbers).map { n,d in Fraction(n,d) }
+        measure {
+            _ = zip(xs,ys).map { x,y in x == y }
+        }
+    }
 }

--- a/Tests/MathTests/RationalTests.swift
+++ b/Tests/MathTests/RationalTests.swift
@@ -255,24 +255,4 @@ class RationalTests: XCTestCase {
         XCTAssertEqual(a, Fraction(44,21))
     }
 
-    // FIXME: Reintroduce once Strideable is recovered
-//    func testStrideableSameDenominator() {
-//        let result = Array(stride(from: Fraction.zero, to: Fraction(4,4), by: Fraction(1,4)))
-//        let expected = [Fraction(0,1), Fraction(1,4), Fraction(2,4), Fraction(3,4)]
-//        XCTAssertEqual(result, expected)
-//    }
-//
-//    func testStrideableDifferentDenominator() {
-//
-//        let result = Array(stride(from: Fraction(1,4), to: Fraction(9,16), by: Fraction(3,32)))
-//
-//        let expected = [
-//            Fraction(8,32),
-//            Fraction(11,32),
-//            Fraction(14,32),
-//            Fraction(17,32)
-//        ]
-//
-//        XCTAssertEqual(result, expected)
-//    }
 }


### PR DESCRIPTION
This PR exposes several operations to cross-module optimization via the `@inlinable` attribute, in some cases with 50% gains.