### PR TITLE
Use hash(into:) for Rational: Hashable conformance

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Structure",
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
-          "branch": "swift-5",
-          "revision": "8f67514cba950f60ee992a8d0996d4f11d9654b0",
-          "version": null
+          "branch": null,
+          "revision": "fc7d6a9dbaeb9c750988a6a142d5f67e395ddf69",
+          "version": "0.23.0"
         }
       }
     ]

--- a/Sources/Math/Rational.swift
+++ b/Sources/Math/Rational.swift
@@ -293,7 +293,8 @@ extension Rational {
 
     /// Hash value.
     ///
-    /// - Note: `Rational` values are hashed by their `floatValue`. That is to say that `1/3` and `2/6` are equivalent.
+    /// - Note: `Rational` values are hashed by their `floatValue`. That is to say that `1/3` and `2/6` are hashed
+    /// equivalently.
     public func hash(into hasher: inout Hasher) {
         hasher.combine(floatValue)
     }

--- a/Sources/Math/Rational.swift
+++ b/Sources/Math/Rational.swift
@@ -292,8 +292,10 @@ extension Rational {
     // MARK: - Hashable
 
     /// Hash value.
-    public var hashValue: Int {
-        return floatValue.hashValue
+    ///
+    /// - Note: `Rational` values are hashed by their `floatValue`. That is to say that `1/3` and `2/6` are equivalent.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(floatValue)
     }
 }
 


### PR DESCRIPTION
Fixes #33.